### PR TITLE
Fix header order in auth handler

### DIFF
--- a/server.go
+++ b/server.go
@@ -113,8 +113,8 @@ func auth_handler(w http.ResponseWriter, r *http.Request) {
 
 	logger.Debug("Response from target server", "data", parsed_user_data)
 	// Optional: Write the response back to the original client
-	w.WriteHeader(resp.StatusCode)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
 
 	// Now we have the SDP and user details, we can accept the connection
 	sdp, err := DecodeFromBase64(payload.SDP)


### PR DESCRIPTION
## Summary
- fix `Content-Type` header placement before calling `WriteHeader`

## Testing
- `go test ./...` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861924d7da88332a408ec9ca3eae550