### PR TITLE
Add mutex protection for CompanySFU maps

### DIFF
--- a/media_orchestration/orchestrator_router_logic.go
+++ b/media_orchestration/orchestrator_router_logic.go
@@ -88,7 +88,10 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						single_connection.MemberTracks[user_id].PipeAudio = pipe_audio
 						single_connection.MemberTracks[user_id].AudioPipeLock.Unlock()
 
-						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
+						company_sfu.CompanySFUsMutex.RLock()
+						user, ok := company_sfu.Users[models.UserId(user_id)]
+						company_sfu.CompanySFUsMutex.RUnlock()
+						if ok {
 							if user.OutgoingDataChannel == nil {
 								continue
 							}
@@ -124,7 +127,10 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						single_connection.MemberTracks[user_id].PipeVideo = pipe_video
 						single_connection.MemberTracks[user_id].VideoPipeLock.Unlock()
 
-						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
+						company_sfu.CompanySFUsMutex.RLock()
+						user, ok := company_sfu.Users[models.UserId(user_id)]
+						company_sfu.CompanySFUsMutex.RUnlock()
+						if ok {
 							if user.OutgoingDataChannel == nil {
 								continue
 							}
@@ -199,13 +205,17 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 				// Send one message per user (even if they’re in multiple rooms)
 				sent := map[models.UserId]bool{}
 				for room_id := range broadcastMap {
+					company_sfu.CompanySFUsMutex.RLock()
 					room := company_sfu.Rooms[room_id]
+					company_sfu.CompanySFUsMutex.RUnlock()
 					for _, room_member_id := range *room.AccessList {
 						uid := models.UserId(room_member_id)
 						if sent[uid] {
 							continue
 						}
+						company_sfu.CompanySFUsMutex.RLock()
 						user, ok := company_sfu.Users[uid]
+						company_sfu.CompanySFUsMutex.RUnlock()
 						if !ok || user.DataChannel == nil {
 							continue
 						}
@@ -267,13 +277,17 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 				// Send one message to all room members
 				sent := map[models.UserId]bool{}
 				for room_id := range broadcastMap {
+					company_sfu.CompanySFUsMutex.RLock()
 					room := company_sfu.Rooms[room_id]
+					company_sfu.CompanySFUsMutex.RUnlock()
 					for _, room_member_id := range *room.AccessList {
 						uid := models.UserId(room_member_id)
 						if sent[uid] {
 							continue
 						}
+						company_sfu.CompanySFUsMutex.RLock()
 						user, ok := company_sfu.Users[uid]
+						company_sfu.CompanySFUsMutex.RUnlock()
 						if !ok || user.DataChannel == nil {
 							continue
 						}
@@ -290,7 +304,9 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 				if to_address == "" {
 					return
 				}
+				company_sfu.CompanySFUsMutex.RLock()
 				user, ok := company_sfu.Users[models.UserId(to_address)]
+				company_sfu.CompanySFUsMutex.RUnlock()
 				if !ok || user.Died || user.Webrtc == nil {
 					return
 				}
@@ -361,9 +377,12 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 			single_connection.MemberTracks = map[string]*models.MemberOutputTrack{}
 			company_sfu.SendOnlineStatus()
 
+			company_sfu.CompanySFUsMutex.Lock()
 			delete(company_sfu.Users, single_connection.UserId)
+			company_sfu.CompanySFUsMutex.Unlock()
 
 			// now I have to remove this member track from all the users.
+			company_sfu.CompanySFUsMutex.RLock()
 			for _, user := range company_sfu.Users {
 				if user.MemberTracks == nil {
 					continue
@@ -420,6 +439,7 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						break
 					}
 				}
+				company_sfu.CompanySFUsMutex.RUnlock()
 			}
 		}
 	})

--- a/models/custom_pli.go
+++ b/models/custom_pli.go
@@ -44,7 +44,10 @@ func SendInstantPLI(track *webrtc.TrackRemote, pc *webrtc.PeerConnection) {
 	}()
 }
 
-func Send_pli_to_company_sfu(sfu *CompanySFU){
+func Send_pli_to_company_sfu(sfu *CompanySFU) {
+	sfu.CompanySFUsMutex.RLock()
+	defer sfu.CompanySFUsMutex.RUnlock()
+
 	for _, user := range sfu.Users {
 		if user.Webrtc == nil {
 			continue

--- a/models/heartbeat_company_sfu.go
+++ b/models/heartbeat_company_sfu.go
@@ -33,10 +33,13 @@ func NewCompanySFU() *CompanySFU {
 }
 
 func (sfu *CompanySFU) RemoveUser(userId UserId) {
+	sfu.CompanySFUsMutex.Lock()
+	defer sfu.CompanySFUsMutex.Unlock()
 	delete(sfu.Users, userId)
 }
 
 func (sfu *CompanySFU) Heartbeat() {
+	sfu.CompanySFUsMutex.RLock()
 	for _, user := range sfu.Users {
 		if user.Died {
 			continue
@@ -65,16 +68,21 @@ func (sfu *CompanySFU) Heartbeat() {
 	}
 
 	// remove dead users
+	sfu.CompanySFUsMutex.RUnlock()
+
+	sfu.CompanySFUsMutex.Lock()
 	for userId, user := range sfu.Users {
 		if user.Died {
 			user.Webrtc.Close()
-			sfu.RemoveUser(userId)
+			delete(sfu.Users, userId)
 			continue
 		}
 	}
+	sfu.CompanySFUsMutex.Unlock()
 }
 
 func (sfu *CompanySFU) SendOnlineStatus() {
+	sfu.CompanySFUsMutex.RLock()
 	userCount := len(sfu.Users)
 	// UserActiveList := []UserId{}
 
@@ -146,10 +154,12 @@ func (sfu *CompanySFU) SendOnlineStatus() {
 			}()
 		}
 	}
+	sfu.CompanySFUsMutex.RUnlock()
 }
 
 func (sfu *CompanySFU) Destroy() {
 	// Close all user connections
+	sfu.CompanySFUsMutex.Lock()
 	for _, user := range sfu.Users {
 		if user.Webrtc != nil {
 			user.Webrtc.Close()
@@ -168,6 +178,7 @@ func (sfu *CompanySFU) Destroy() {
 	// Clear maps
 	sfu.Users = nil
 	sfu.Rooms = nil
+	sfu.CompanySFUsMutex.Unlock()
 }
 
 func (sfu *CompanySFU) StartOnlineStatusBroadcaster() {

--- a/models/rtp_track_syncronizer_and_orchestraction.go
+++ b/models/rtp_track_syncronizer_and_orchestraction.go
@@ -51,16 +51,18 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 
 				for _, user := range company_sfu.Users {
 
-
 					if user.UserId == peer_connection.UserId {
 						continue
 					}
 
-					if _, ok := company_sfu.Users[user.UserId]; !ok {
+					company_sfu.CompanySFUsMutex.RLock()
+					u, ok := company_sfu.Users[user.UserId]
+					company_sfu.CompanySFUsMutex.RUnlock()
+					if !ok {
 						continue
 					}
 
-					if company_sfu.Users[user.UserId] == nil || company_sfu.Users[user.UserId].Webrtc == nil {
+					if u == nil || u.Webrtc == nil {
 						continue
 					}
 
@@ -155,11 +157,14 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 						continue
 					}
 
-					if _, ok := company_sfu.Users[user.UserId]; !ok {
+					company_sfu.CompanySFUsMutex.RLock()
+					u, ok := company_sfu.Users[user.UserId]
+					company_sfu.CompanySFUsMutex.RUnlock()
+					if !ok {
 						continue
 					}
 
-					if company_sfu.Users[user.UserId] == nil || company_sfu.Users[user.UserId].Webrtc == nil {
+					if u == nil || u.Webrtc == nil {
 						continue
 					}
 					// Peerconnection is sending the RTP tracks for the user to receive the connection to him must be stable.
@@ -330,8 +335,10 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 
 			track_exists := false
 
+			company_sfu.CompanySFUsMutex.RLock()
 			audio_track := company_sfu.Users[users_connction_check.UserId].AudioReceiver
 			video_track := company_sfu.Users[users_connction_check.UserId].VideoReceiver
+			company_sfu.CompanySFUsMutex.RUnlock()
 
 			if audio_track != nil {
 
@@ -399,11 +406,14 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 
 func AddAudioTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_connction_check *FullConnectionDetails) (error, bool) {
 
-	if _, ok := company_sfu.Users[users_connction_check.UserId]; !ok {
+	company_sfu.CompanySFUsMutex.RLock()
+	trackUser, ok := company_sfu.Users[users_connction_check.UserId]
+	company_sfu.CompanySFUsMutex.RUnlock()
+	if !ok {
 		return fmt.Errorf("user not found in company sfu"), false
 	}
 
-	track := company_sfu.Users[users_connction_check.UserId].AudioReceiver
+	track := trackUser.AudioReceiver
 
 	audioTrack, err := webrtc.NewTrackLocalStaticRTP(
 		webrtc.RTPCodecCapability{
@@ -446,11 +456,14 @@ func AddAudioTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_c
 
 func AddVideoTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_connction_check *FullConnectionDetails) (error, bool) {
 
-	if _, ok := company_sfu.Users[users_connction_check.UserId]; !ok {
+	company_sfu.CompanySFUsMutex.RLock()
+	trackUser, ok := company_sfu.Users[users_connction_check.UserId]
+	company_sfu.CompanySFUsMutex.RUnlock()
+	if !ok {
 		return fmt.Errorf("user not found in company sfu"), false
 	}
 
-	track := company_sfu.Users[users_connction_check.UserId].VideoReceiver
+	track := trackUser.VideoReceiver
 
 	VideoTrack, err := webrtc.NewTrackLocalStaticRTP(
 		webrtc.RTPCodecCapability{


### PR DESCRIPTION
## Summary
- guard Users and Rooms with `CompanySFUsMutex`
- protect Send_pli_to_company_sfu with read lock
- lock map access in orchestrator and RTP sync logic

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_6861945fec048332bc3a02ea24dacada