### PR TITLE
Ensure consistent locking for CompanySFU users

### DIFF
--- a/media_orchestration/orchestrator_router_logic.go
+++ b/media_orchestration/orchestrator_router_logic.go
@@ -88,7 +88,10 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						single_connection.MemberTracks[user_id].PipeAudio = pipe_audio
 						single_connection.MemberTracks[user_id].AudioPipeLock.Unlock()
 
-						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
+						company_sfu.CompanySFUsMutex.RLock()
+						user, ok := company_sfu.Users[models.UserId(user_id)]
+						company_sfu.CompanySFUsMutex.RUnlock()
+						if ok {
 							if user.OutgoingDataChannel == nil {
 								continue
 							}
@@ -124,7 +127,10 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						single_connection.MemberTracks[user_id].PipeVideo = pipe_video
 						single_connection.MemberTracks[user_id].VideoPipeLock.Unlock()
 
-						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
+						company_sfu.CompanySFUsMutex.RLock()
+						user, ok := company_sfu.Users[models.UserId(user_id)]
+						company_sfu.CompanySFUsMutex.RUnlock()
+						if ok {
 							if user.OutgoingDataChannel == nil {
 								continue
 							}
@@ -198,6 +204,7 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 
 				// Send one message per user (even if they’re in multiple rooms)
 				sent := map[models.UserId]bool{}
+				company_sfu.CompanySFUsMutex.RLock()
 				for room_id := range broadcastMap {
 					room := company_sfu.Rooms[room_id]
 					for _, room_member_id := range *room.AccessList {
@@ -218,6 +225,7 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						sent[uid] = true
 					}
 				}
+				company_sfu.CompanySFUsMutex.RUnlock()
 			} else if payload.Type == "audio_route_room" {
 				fmt.Println("Received room audio route data:", payload.Audio_route_room)
 
@@ -266,6 +274,7 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 
 				// Send one message to all room members
 				sent := map[models.UserId]bool{}
+				company_sfu.CompanySFUsMutex.RLock()
 				for room_id := range broadcastMap {
 					room := company_sfu.Rooms[room_id]
 					for _, room_member_id := range *room.AccessList {
@@ -285,12 +294,15 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 						sent[uid] = true
 					}
 				}
+				company_sfu.CompanySFUsMutex.RUnlock()
 			} else if payload.Type == "route_to" {
 				to_address := payload.Route_to
 				if to_address == "" {
 					return
 				}
+				company_sfu.CompanySFUsMutex.RLock()
 				user, ok := company_sfu.Users[models.UserId(to_address)]
+				company_sfu.CompanySFUsMutex.RUnlock()
 				if !ok || user.Died || user.Webrtc == nil {
 					return
 				}
@@ -361,9 +373,12 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 			single_connection.MemberTracks = map[string]*models.MemberOutputTrack{}
 			company_sfu.SendOnlineStatus()
 
+			company_sfu.CompanySFUsMutex.Lock()
 			delete(company_sfu.Users, single_connection.UserId)
+			company_sfu.CompanySFUsMutex.Unlock()
 
 			// now I have to remove this member track from all the users.
+			company_sfu.CompanySFUsMutex.RLock()
 			for _, user := range company_sfu.Users {
 				if user.MemberTracks == nil {
 					continue
@@ -421,6 +436,7 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 					}
 				}
 			}
+			company_sfu.CompanySFUsMutex.RUnlock()
 		}
 	})
 

--- a/models/heartbeat_company_sfu.go
+++ b/models/heartbeat_company_sfu.go
@@ -33,7 +33,9 @@ func NewCompanySFU() *CompanySFU {
 }
 
 func (sfu *CompanySFU) RemoveUser(userId UserId) {
+	sfu.CompanySFUsMutex.Lock()
 	delete(sfu.Users, userId)
+	sfu.CompanySFUsMutex.Unlock()
 }
 
 func (sfu *CompanySFU) Heartbeat() {

--- a/server.go
+++ b/server.go
@@ -212,9 +212,11 @@ func auth_handler(w http.ResponseWriter, r *http.Request) {
 		mediaorchestration.Initialize_renegotiation(fcd)
 	}
 
+	CompanySFUs[parsed_user_data.CompanyID].CompanySFUsMutex.Lock()
 	if _, ok := CompanySFUs[parsed_user_data.CompanyID].Users[models.UserId(parsed_user_data.User.ID)]; !ok {
 		CompanySFUs[parsed_user_data.CompanyID].Users[models.UserId(parsed_user_data.User.ID)] = UserConnections[parsed_user_data.User.ID]
 	}
+	CompanySFUs[parsed_user_data.CompanyID].CompanySFUsMutex.Unlock()
 
 	res_payload := map[string]interface{}{
 		"SDP":    EncodeToBase64(UserConnections[parsed_user_data.User.ID].AnswerSDP),


### PR DESCRIPTION
## Summary
- add mutex protection when removing a user from `CompanySFU`
- protect user map access when registering a user in `server.go`
- guard all reads/writes of `company_sfu.Users` in `SingleOrchestrator`

## Testing
- `go test ./...` *(fails: forbidden to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68619461e2208332946f6483c17135ca