### PR TITLE
Ensure MemberTracks access locked

### DIFF
--- a/media_orchestration/orchestrator_router_logic.go
+++ b/media_orchestration/orchestrator_router_logic.go
@@ -81,13 +81,17 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 			} else if payload.Type == "audio_route" {
 				fmt.Println("Received audio route data:", payload.Audio_route)
 				for user_id, pipe_audio := range payload.Audio_route {
-					if single_connection.MemberTracks != nil &&
-						single_connection.MemberTracks[user_id] != nil {
-
+					single_connection.MemberLock.Lock()
+					trackExists := single_connection.MemberTracks != nil &&
+						single_connection.MemberTracks[user_id] != nil
+					if trackExists {
 						single_connection.MemberTracks[user_id].AudioPipeLock.Lock()
 						single_connection.MemberTracks[user_id].PipeAudio = pipe_audio
 						single_connection.MemberTracks[user_id].AudioPipeLock.Unlock()
+					}
+					single_connection.MemberLock.Unlock()
 
+					if trackExists {
 						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
 							if user.OutgoingDataChannel == nil {
 								continue
@@ -117,13 +121,17 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 			} else if payload.Type == "video_route" {
 				fmt.Println("Received video route data:", payload.Video_route)
 				for user_id, pipe_video := range payload.Video_route {
-					if single_connection.MemberTracks != nil &&
-						single_connection.MemberTracks[user_id] != nil {
-
+					single_connection.MemberLock.Lock()
+					trackExists := single_connection.MemberTracks != nil &&
+						single_connection.MemberTracks[user_id] != nil
+					if trackExists {
 						single_connection.MemberTracks[user_id].VideoPipeLock.Lock()
 						single_connection.MemberTracks[user_id].PipeVideo = pipe_video
 						single_connection.MemberTracks[user_id].VideoPipeLock.Unlock()
+					}
+					single_connection.MemberLock.Unlock()
 
+					if trackExists {
 						if user, ok := company_sfu.Users[models.UserId(user_id)]; ok {
 							if user.OutgoingDataChannel == nil {
 								continue
@@ -358,20 +366,23 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 			single_connection.DiedLock.Lock()
 			single_connection.Died = true
 			single_connection.DiedLock.Unlock()
+			single_connection.MemberLock.Lock()
 			single_connection.MemberTracks = map[string]*models.MemberOutputTrack{}
+			single_connection.MemberLock.Unlock()
 			company_sfu.SendOnlineStatus()
 
 			delete(company_sfu.Users, single_connection.UserId)
 
 			// now I have to remove this member track from all the users.
 			for _, user := range company_sfu.Users {
+				user.MemberLock.Lock()
 				if user.MemberTracks == nil {
+					user.MemberLock.Unlock()
 					continue
 				}
+				removed := false
 				for member_id := range user.MemberTracks {
 					if member_id == string(single_connection.UserId) {
-
-						user.MemberLock.Lock()
 						if user.MemberTracks[member_id].AudioTrack != nil {
 							user.MemberTracks[member_id].AudioTrack.Stop()
 
@@ -418,6 +429,9 @@ func SingleOrchestrator(single_connection *models.FullConnectionDetails, company
 							fmt.Println("User is dead or WebRTC is nil, skipping renegotiation.")
 						}
 						break
+					}
+					if !removed {
+						user.MemberLock.Unlock()
 					}
 				}
 			}

--- a/media_orchestration/peer_creation.go
+++ b/media_orchestration/peer_creation.go
@@ -12,7 +12,7 @@ import (
 func CreateOffer() (*models.FullConnectionDetails, error) {
 	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{
 		ICETransportPolicy: webrtc.ICETransportPolicyAll,
-		ICEServers: []webrtc.ICEServer{
+		ICEServers:         []webrtc.ICEServer{
 			// {
 			// 	URLs:           []string{"turn:jo.vldo.in:3478?transport=udp"},
 			// 	Username:       "thianesh",
@@ -154,12 +154,15 @@ func CreateAnswer(
 		// AudioSenderTrack: audioTrack,
 		OfferSDP:            remoteOfferSDP,
 		UserId:              models.UserId(parsed_user_data.User.ID),
-		MemberTracks:        map[string]*models.MemberOutputTrack{},
 		CompanySFU:          company_sfu,
 		AudioRoomsMap:       make(map[string]bool),
 		VideoRoomsMap:       make(map[string]bool),
 		OutgoingDataChannel: make(chan []byte, 250),
 	}
+
+	full_connection.MemberLock.Lock()
+	full_connection.MemberTracks = map[string]*models.MemberOutputTrack{}
+	full_connection.MemberLock.Unlock()
 
 	attach_ontrack_member_track_sync(full_connection, company_sfu)
 

--- a/models/heartbeat_company_sfu.go
+++ b/models/heartbeat_company_sfu.go
@@ -93,6 +93,7 @@ func (sfu *CompanySFU) SendOnlineStatus() {
 
 			members_media_ids := make(map[UserId]media_details, userCount)
 
+			user.MemberLock.Lock()
 			for member_id, member_track := range user.MemberTracks {
 				audio_track_id := ""
 				video_track_id := ""
@@ -103,6 +104,7 @@ func (sfu *CompanySFU) SendOnlineStatus() {
 					audio_track_id = member_track.AudioSenderTrack.ID()
 					audio_stream_id = member_track.AudioSenderTrack.StreamID()
 				}
+				user.MemberLock.Unlock()
 				if member_track.VideoTrack != nil {
 					video_track_id = member_track.VideoSenderTrack.ID()
 					video_stream_id = member_track.VideoSenderTrack.StreamID()

--- a/models/rtp_track_syncronizer_and_orchestraction.go
+++ b/models/rtp_track_syncronizer_and_orchestraction.go
@@ -51,7 +51,6 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 
 				for _, user := range company_sfu.Users {
 
-
 					if user.UserId == peer_connection.UserId {
 						continue
 					}
@@ -77,32 +76,38 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 
 					// fmt.Println("Signaling state is stable for user", user.Email, user.UserId, "state:", user.Webrtc.SignalingState(), "and peer connection", peer_connection.Email, peer_connection.UserId, "state:", peer_connection.Webrtc.SignalingState())
 
-					if user.MemberTracks[string(peer_connection.UserId)] == nil {
+					user.MemberLock.Lock()
+					memberTrack := user.MemberTracks[string(peer_connection.UserId)]
+					user.MemberLock.Unlock()
+					if memberTrack == nil {
 						fmt.Println("Member Track (AudioTrack + VideoTrack) is nill for ", peer_connection.UserId)
 						company_sfu.RtpSyncNeeded = true
 						// go sysc_user_tracks_and_renegotiate(company_sfu)
 						continue
 					}
 
-					if user.MemberTracks[string(peer_connection.UserId)].AudioTrack == nil {
+					if memberTrack.AudioTrack == nil {
 						fmt.Println("Audio track is nill for ", string(peer_connection.UserId))
 						company_sfu.RtpSyncNeeded = true
 						// go sysc_user_tracks_and_renegotiate(company_sfu)
 						continue
 					}
 
-					if peer_connection.MemberTracks[string(user.UserId)] == nil {
+					peer_connection.MemberLock.Lock()
+					peerTrack := peer_connection.MemberTracks[string(user.UserId)]
+					peer_connection.MemberLock.Unlock()
+					if peerTrack == nil {
 						continue
 					}
 					// Route check
-					peer_connection.MemberTracks[string(user.UserId)].AudioPipeLock.Lock()
-					should_pipe := peer_connection.MemberTracks[string(user.UserId)].PipeAudio
-					peer_connection.MemberTracks[string(user.UserId)].AudioPipeLock.Unlock()
+					peerTrack.AudioPipeLock.Lock()
+					should_pipe := peerTrack.PipeAudio
+					peerTrack.AudioPipeLock.Unlock()
 
 					// Route check
 					if should_pipe {
 						select {
-						case user.MemberTracks[string(peer_connection.UserId)].AudioBuffer <- rtp.Clone():
+						case memberTrack.AudioBuffer <- rtp.Clone():
 							continue
 							// successfully passed to buff
 						default:
@@ -121,7 +126,7 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 						}
 						if Contains(*company_sfu.Rooms[RoomId(room_id)].AccessList, string(peer_connection.UserId)) {
 							select {
-							case user.MemberTracks[string(peer_connection.UserId)].AudioBuffer <- rtp.Clone():
+							case memberTrack.AudioBuffer <- rtp.Clone():
 								continue
 								// successfully passed to buff
 							default:
@@ -175,32 +180,37 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 
 					// fmt.Println("Signaling state is stable for user", user.Email, user.UserId, "state:", user.Webrtc.SignalingState(), "and peer connection", peer_connection.Email, peer_connection.UserId, "state:", peer_connection.Webrtc.SignalingState())
 
-					if user.MemberTracks[string(peer_connection.UserId)] == nil {
+					user.MemberLock.Lock()
+					memberTrack := user.MemberTracks[string(peer_connection.UserId)]
+					user.MemberLock.Unlock()
+					if memberTrack == nil {
 						fmt.Println("Member Track (AudioTrack + VideoTrack) is nill for ", peer_connection.UserId, "for user", user.Email, user.UserId)
 						company_sfu.RtpSyncNeeded = true
 						// go sysc_user_tracks_and_renegotiate(company_sfu)
 						continue
 					}
-
-					if user.MemberTracks[string(peer_connection.UserId)].VideoTrack == nil {
+					if memberTrack.VideoTrack == nil {
 						fmt.Println("Video track is nill for ", string(peer_connection.UserId), "for user", user.Email, user.UserId)
 						company_sfu.RtpSyncNeeded = true
 						// go sysc_user_tracks_and_renegotiate(company_sfu)
 						continue
 					}
 
-					if peer_connection.MemberTracks[string(user.UserId)] == nil {
+					peer_connection.MemberLock.Lock()
+					peerTrack := peer_connection.MemberTracks[string(user.UserId)]
+					peer_connection.MemberLock.Unlock()
+					if peerTrack == nil {
 						continue
 					}
 
 					// Route check
-					peer_connection.MemberTracks[string(user.UserId)].VideoPipeLock.Lock()
-					should_pipe := peer_connection.MemberTracks[string(user.UserId)].PipeVideo
-					peer_connection.MemberTracks[string(user.UserId)].VideoPipeLock.Unlock()
+					peerTrack.VideoPipeLock.Lock()
+					should_pipe := peerTrack.PipeVideo
+					peerTrack.VideoPipeLock.Unlock()
 
 					if should_pipe {
 						select {
-						case user.MemberTracks[string(peer_connection.UserId)].VideoBuffer <- rtp.Clone():
+						case memberTrack.VideoBuffer <- rtp.Clone():
 							continue
 							// successfully passed to buff
 						default:
@@ -219,7 +229,7 @@ func Sync_track(peer_connection *FullConnectionDetails, company_sfu *CompanySFU)
 						}
 						if Contains(*company_sfu.Rooms[RoomId(room_id)].AccessList, string(peer_connection.UserId)) {
 							select {
-							case user.MemberTracks[string(peer_connection.UserId)].VideoBuffer <- rtp.Clone():
+							case memberTrack.VideoBuffer <- rtp.Clone():
 								continue
 								// successfully passed to buff
 							default:
@@ -317,9 +327,11 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 			continue
 		}
 
+		user.MemberLock.Lock()
 		if user.MemberTracks == nil {
 			user.MemberTracks = map[string]*MemberOutputTrack{}
 		}
+		user.MemberLock.Unlock()
 
 		// Each user should have all the memebers connection except his own
 		for _, users_connction_check := range company_sfu.Users {
@@ -336,15 +348,18 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 			if audio_track != nil {
 
 				// If audio track is not present for the user, we will add it
-				if _, ok := user.MemberTracks[string(users_connction_check.UserId)]; ok {
-					if user.MemberTracks[string(users_connction_check.UserId)].AudioSenderTrack == nil {
+				user.MemberLock.Lock()
+				mt, ok := user.MemberTracks[string(users_connction_check.UserId)]
+				user.MemberLock.Unlock()
+				if ok {
+					if mt.AudioSenderTrack == nil {
 						if _, ok := AddAudioTrack(user, company_sfu, users_connction_check); ok {
 							fmt.Println("Added audio track for", users_connction_check.Email, " to the user", user.Email, user.UserId)
 							track_exists = true
-
-							// now adding the buffer
+							user.MemberLock.Lock()
 							user.MemberTracks[string(users_connction_check.UserId)].AudioBuffer = make(chan *rtp.Packet, 256)
 							go Forward(user.MemberTracks[string(users_connction_check.UserId)].AudioBuffer, user.MemberTracks[string(users_connction_check.UserId)].AudioSenderTrack, string(users_connction_check.UserId)+">> audio")
+							user.MemberLock.Unlock()
 						}
 					}
 				} else {
@@ -352,10 +367,10 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 					if _, ok := AddAudioTrack(user, company_sfu, users_connction_check); ok {
 						fmt.Println("Added audio track for", users_connction_check.Email, " to the user", user.Email, user.UserId)
 						track_exists = true
-
-						// now adding the buffer
+						user.MemberLock.Lock()
 						user.MemberTracks[string(users_connction_check.UserId)].AudioBuffer = make(chan *rtp.Packet, 256)
 						go Forward(user.MemberTracks[string(users_connction_check.UserId)].AudioBuffer, user.MemberTracks[string(users_connction_check.UserId)].AudioSenderTrack, string(users_connction_check.UserId)+">> audio")
+						user.MemberLock.Unlock()
 					}
 				}
 
@@ -364,15 +379,18 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 			if video_track != nil {
 
 				// If audio track is not present for the user, we will add it
-				if _, ok := user.MemberTracks[string(users_connction_check.UserId)]; ok {
-					if user.MemberTracks[string(users_connction_check.UserId)].VideoSenderTrack == nil {
+				user.MemberLock.Lock()
+				mt, ok = user.MemberTracks[string(users_connction_check.UserId)]
+				user.MemberLock.Unlock()
+				if ok {
+					if mt.VideoSenderTrack == nil {
 						if _, ok := AddVideoTrack(user, company_sfu, users_connction_check); ok {
 							fmt.Println("Added video track for", users_connction_check.Email, " to the user", user.Email, user.UserId)
 							track_exists = true
-
-							// now adding the buffer
+							user.MemberLock.Lock()
 							user.MemberTracks[string(users_connction_check.UserId)].VideoBuffer = make(chan *rtp.Packet, 1024)
 							go Forward(user.MemberTracks[string(users_connction_check.UserId)].VideoBuffer, user.MemberTracks[string(users_connction_check.UserId)].VideoSenderTrack, string(users_connction_check.UserId)+">> video")
+							user.MemberLock.Unlock()
 
 						}
 					}
@@ -381,10 +399,10 @@ func sysc_user_tracks_and_renegotiate(company_sfu *CompanySFU) {
 					if _, ok := AddVideoTrack(user, company_sfu, users_connction_check); ok {
 						fmt.Println("Added video track for", users_connction_check.Email, " to the user", user.Email, user.UserId)
 						track_exists = true
-
-						// now adding the buffer
+						user.MemberLock.Lock()
 						user.MemberTracks[string(users_connction_check.UserId)].VideoBuffer = make(chan *rtp.Packet, 1024)
 						go Forward(user.MemberTracks[string(users_connction_check.UserId)].VideoBuffer, user.MemberTracks[string(users_connction_check.UserId)].VideoSenderTrack, string(users_connction_check.UserId)+">> video")
+						user.MemberLock.Unlock()
 					}
 				}
 
@@ -429,6 +447,7 @@ func AddAudioTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_c
 		return err, false
 	}
 
+	user.MemberLock.Lock()
 	if user.MemberTracks[string(users_connction_check.UserId)] == nil {
 		user.MemberTracks[string(users_connction_check.UserId)] = &MemberOutputTrack{
 			Accessible: true,
@@ -441,6 +460,7 @@ func AddAudioTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_c
 	user.MemberTracks[string(users_connction_check.UserId)].DataTrack = users_connction_check.DataChannel
 	user.MemberTracks[string(users_connction_check.UserId)].Status = "online"
 	user.MemberTracks[string(users_connction_check.UserId)].Accessible = true
+	user.MemberLock.Unlock()
 	return nil, true
 }
 
@@ -476,6 +496,7 @@ func AddVideoTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_c
 		return err, false
 	}
 
+	user.MemberLock.Lock()
 	if user.MemberTracks[string(users_connction_check.UserId)] == nil {
 		user.MemberTracks[string(users_connction_check.UserId)] = &MemberOutputTrack{
 			Accessible: true,
@@ -488,6 +509,7 @@ func AddVideoTrack(user *FullConnectionDetails, company_sfu *CompanySFU, users_c
 	user.MemberTracks[string(users_connction_check.UserId)].DataTrack = users_connction_check.DataChannel
 	user.MemberTracks[string(users_connction_check.UserId)].Status = "online"
 	user.MemberTracks[string(users_connction_check.UserId)].Accessible = true
+	user.MemberLock.Unlock()
 	return nil, true
 }
 


### PR DESCRIPTION
## Summary
- protect MemberTracks modifications with MemberLock
- lock when creating new connection and when syncing tracks
- guard status broadcasts using the mutex

## Testing
- `go vet ./...` *(fails: Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68619462e0808332826e9adda7df931f